### PR TITLE
Implement HDR toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # About
 enhanced-h264ify is a fork of well-known h264ify extension for Firefox/Chrome which blocks VP8/VP9 codecs on YouTube, so that you can use H264 only. This may be useful because there are lots of devices on the market which support H264 hardware decoding and do not support VP8/VP9.
 
-This extension has new features such as manual blocking of H264, VP8, VP9, AV1 codecs and 60fps video. By default it blocks everything but H264 and 60fps video.
+This extension has new features such as manual blocking of H264, VP8, VP9, AV1 codecs and 60fps or HDR videos. By default it blocks everything but H264 and 60fps/HDR videos.
 It works only on YouTube.
 
 # Installation

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -12,6 +12,10 @@
     "message": "Block 60fps video"
   },
 
+  "optionsBlockHDR": {
+    "message": "Block HDR video"
+  },
+
   "optionsBlockH264": {
     "message": "Block h264"
   },

--- a/options.html
+++ b/options.html
@@ -16,6 +16,7 @@
       <h4 data-l10n-id="optionsTitle"></h4>
       <ul>
          <li><input type="checkbox" id="block_60fps" class="checkbox"><label for="block_60fps" data-l10n-id="optionsBlock60fps"></label></li>
+         <li><input type="checkbox" id="block_HDR" class="checkbox"><label for="block_HDR" data-l10n-id="optionsBlockHDR"></label></li>
          <li><input type="checkbox" id="block_h264" class="checkbox"><label for="block_h264" data-l10n-id="optionsBlockH264"></label></li>
          <li><input type="checkbox" id="block_vp8" class="checkbox"><label for="block_vp8" data-l10n-id="optionsBlockVP8"></label></li>
          <li><input type="checkbox" id="block_vp9" class="checkbox"><label for="block_vp9" data-l10n-id="optionsBlockVP9"></label></li>

--- a/options.js
+++ b/options.js
@@ -52,5 +52,5 @@ for (var i = 0; i < checkboxes.length; i++) {
 
 // l10n
 for (let element of document.querySelectorAll('[data-l10n-id]')) {
-  element.textContent = chrome.i18n.getMessage(element.dataset.l10nId);
+  element.textContent = chrome.i18n.getMessage(element.dataset.l10nId) || element.dataset.l10nId;
 }

--- a/options.js
+++ b/options.js
@@ -1,6 +1,7 @@
 // Saves options to chrome.storage
 function save_options() {
   var block_60fps = document.getElementById('block_60fps').checked;
+  var block_HDR = document.getElementById('block_HDR').checked;
   var block_h264 = document.getElementById('block_h264').checked;
   var block_vp8 = document.getElementById('block_vp8').checked;
   var block_vp9 = document.getElementById('block_vp9').checked;
@@ -9,6 +10,7 @@ function save_options() {
   var disable_LN = document.getElementById('disable_LN').checked;
   chrome.storage.local.set({
     block_60fps: block_60fps,
+    block_HDR: block_HDR,
     block_h264: block_h264,
     block_vp8: block_vp8,
     block_vp9: block_vp9,
@@ -22,6 +24,7 @@ function restore_options() {
   // Default values
   chrome.storage.local.get({
     block_60fps: false,
+    block_HDR: false,
     block_h264: false,
     block_vp8: true,
     block_vp9: true,
@@ -29,6 +32,7 @@ function restore_options() {
     disable_LN: false
   }, function(options) {
     document.getElementById('block_60fps').checked = options.block_60fps;
+    document.getElementById('block_HDR').checked = options.block_HDR;
     document.getElementById('block_h264').checked = options.block_h264;
     document.getElementById('block_vp8').checked = options.block_vp8;
     document.getElementById('block_vp9').checked = options.block_vp9;

--- a/src/inject/content_script.js
+++ b/src/inject/content_script.js
@@ -31,6 +31,9 @@
 if (localStorage['enhanced-h264ify-block_60fps'] === undefined) {
   localStorage['enhanced-h264ify-block_60fps'] = false;
 }
+if (localStorage['enhanced-h264ify-block_HDR'] === undefined) {
+  localStorage['enhanced-h264ify-block_HDR'] = false;
+}
 if (localStorage['enhanced-h264ify-block_h264'] === undefined) {
   localStorage['enhanced-h264ify-block_h264'] = false;
 }
@@ -54,6 +57,7 @@ if (localStorage['enhanced-h264ify-disable_LN'] === undefined) {
 chrome.storage.local.get({
   // Set defaults
   block_60fps: false,
+  block_HDR: false,
   block_h264: false,
   block_vp8: true,
   block_vp9: true,
@@ -61,6 +65,7 @@ chrome.storage.local.get({
   disable_LN: false
  }, function(options) {
    localStorage['enhanced-h264ify-block_60fps'] = options.block_60fps;
+   localStorage['enhanced-h264ify-block_HDR'] = options.block_HDR;
    localStorage['enhanced-h264ify-block_h264'] = options.block_h264;
    localStorage['enhanced-h264ify-block_vp8'] = options.block_vp8;
    localStorage['enhanced-h264ify-block_vp9'] = options.block_vp9;

--- a/src/inject/inject.js
+++ b/src/inject/inject.js
@@ -76,8 +76,6 @@ function inject () {
         const match = /codecs="(.*)"/.exec(type);
         const codecs = match && match[1] ? match && match[1] : '';
 
-        console.log(codecs);
-
         const HDRTransferCharacteristics = [
           '16', // SMPTE ST 2084 Perceptual Quantizer
           '18' // BT.2100 Hybrid Log Gamma 
@@ -97,19 +95,6 @@ function inject () {
             videoFullRangeFlag
           ] = codecs.split('.');
 
-          Object.entries({
-            fourCharacterCode,
-            profile,
-            level,
-            bitDepth,
-            monochrome,
-            chromaSubsampling,
-            colorPrimaries,
-            transferCharacteristics,
-            matrixCoefficients,
-            videoFullRangeFlag
-          }).forEach((entries) => console.log('-', ...entries));
-
           if (HDRTransferCharacteristics.includes(transferCharacteristics)) return '';
 
         } else if (/^vp\d\d/.test(codecs)) {
@@ -124,18 +109,6 @@ function inject () {
             matrixCoefficients,
             videoFullRangeFlag
           ] = codecs.split('.');
-
-          Object.entries({
-            fourCharacterCode,
-            profile,
-            level,
-            bitDepth,
-            chromaSubsampling,
-            colorPrimaries,
-            transferCharacteristics,
-            matrixCoefficients,
-            videoFullRangeFlag,
-          }).forEach((entries) => console.log('-', ...entries));
 
           if (HDRTransferCharacteristics.includes(transferCharacteristics)) return '';
         }

--- a/src/inject/inject.js
+++ b/src/inject/inject.js
@@ -70,6 +70,77 @@ function inject () {
         if (match && match[1] > 30) return '';
       }
 
+      if (localStorage['enhanced-h264ify-block_HDR'] === 'true') {
+        // parse AV1 and VP8/VP9 format strings
+        // see https://developer.mozilla.org/en-US/docs/Web/Media/Formats/codecs_parameter
+        const match = /codecs="(.*)"/.exec(type);
+        const codecs = match && match[1] ? match && match[1] : '';
+
+        console.log(codecs);
+
+        const HDRTransferCharacteristics = [
+          '16', // SMPTE ST 2084 Perceptual Quantizer
+          '18' // BT.2100 Hybrid Log Gamma 
+        ];
+
+        if (/^av01/.test(codecs)) {
+          const [
+            fourCharacterCode,
+            profile,
+            level,
+            bitDepth,
+            monochrome,
+            chromaSubsampling,
+            colorPrimaries,
+            transferCharacteristics,
+            matrixCoefficients,
+            videoFullRangeFlag
+          ] = codecs.split('.');
+
+          Object.entries({
+            fourCharacterCode,
+            profile,
+            level,
+            bitDepth,
+            monochrome,
+            chromaSubsampling,
+            colorPrimaries,
+            transferCharacteristics,
+            matrixCoefficients,
+            videoFullRangeFlag
+          }).forEach((entries) => console.log('-', ...entries));
+
+          if (HDRTransferCharacteristics.includes(transferCharacteristics)) return '';
+
+        } else if (/^vp\d\d/.test(codecs)) {
+          const [
+            fourCharacterCode,
+            profile,
+            level,
+            bitDepth,
+            chromaSubsampling,
+            colorPrimaries,
+            transferCharacteristics,
+            matrixCoefficients,
+            videoFullRangeFlag
+          ] = codecs.split('.');
+
+          Object.entries({
+            fourCharacterCode,
+            profile,
+            level,
+            bitDepth,
+            chromaSubsampling,
+            colorPrimaries,
+            transferCharacteristics,
+            matrixCoefficients,
+            videoFullRangeFlag,
+          }).forEach((entries) => console.log('-', ...entries));
+
+          if (HDRTransferCharacteristics.includes(transferCharacteristics)) return '';
+        }
+      }
+
       // Otherwise, ask the browser
       return origChecker(type);
     };


### PR DESCRIPTION
This adds an additional feature to the extension to allow users to toggle HDR video off. It parses the VP8/VP9 and AV1 format strings to determine whether they use an HDR transfer function.