### PR TITLE
Fix fps values between 31 and 48

### DIFF
--- a/src/inject/inject.js
+++ b/src/inject/inject.js
@@ -67,7 +67,7 @@ function inject () {
 
       if (localStorage['enhanced-h264ify-block_60fps'] === 'true') {
         var match = /framerate=(\d+)/.exec(type);
-        if (match && match[1] > 30) return '';
+        if (match && match[1] >= 48) return '';
       }
 
       // Otherwise, ask the browser


### PR DESCRIPTION
Currently, this extension's option to disable "60fps" high frame rate video will disable any source whose frame rate is higher than 30.

This breaks on https://www.youtube.com/watch?v=CDIO5aNGmF8, whose "247" video format (a 1280x720@30fps VP9-encoded stream, the best non-HFR encoding that Youtube currently generates from HFR uploads) mysteriously has metadata indicating its frame rate as 37fps. Therefore, with the current extension code, this video is limited to 480p.

This PR changes the check to only treat frame rates of 48fps and higher as high frame rate video. This ensures that content with 24fps and 48fps versions (i.e. [The Hobbit movie clips](https://www.youtube.com/watch?v=s7KIMfFYbi8) and essentially nothing else) will have their HFR options disabled by the toggle, but that anything less than that will continue to work.